### PR TITLE
Termux Support

### DIFF
--- a/duckfetch
+++ b/duckfetch
@@ -13,12 +13,21 @@ BOLD="\x1B[1m"
 RESET="\x1B[0m"
 
 displayInfo() {
-    d_title=$USER@$HOSTNAME
-    d_user=$(whoami)
-    d_os=$(grep -m1 "NAME=" < /etc/os-release | cut -d '"' -f 2)
-    d_uptime=$(uptime -p)
-    d_font=$(fc-match | sed 's/\..*//g')
-    d_shell=$(basename $SHELL)
+    if [[ $(uname -o) == "Android" ]]; then
+        d_user=$(whoami)
+        d_title=$d_user@$HOSTNAME
+        d_os="Android $(getprop ro.build.version.release)"
+        d_uptime=$(uptime -p)
+        d_font=""
+        d_shell=$(basename $SHELL)
+    else
+        d_title=$USER@$HOSTNAME
+        d_user=$(whoami)
+        d_os=$(grep -m1 "NAME=" < /etc/os-release | cut -d '"' -f 2)
+        d_uptime=$(uptime -p)
+        d_font=$(fc-match | sed 's/\..*//g')
+        d_shell=$(basename $SHELL)
+    fi
 }
 
 setInfo() {

--- a/install
+++ b/install
@@ -2,14 +2,16 @@
 
 FILE="duckfetch"
 
-[ "$UID" -eq 0 ] || exec sudo bash "$0" "$@"
-
 if [[ ! -f "./$FILE" ]]; then
     echo "The 'duckfetch' script does not exist."
     exit
 fi
 
-sudo cp ./$FILE /usr/bin
+if [[ $(uname -o) == "Android" ]]; then
+	cp ./$FILE /data/data/com.termux/files/usr/bin
+else
+	sudo cp ./$FILE /usr/bin
+fi
 
 echo "Installation complete. Run the 'duckfetch' command."
 echo "If you have any issue, please report them in the issues tab."


### PR DESCRIPTION
Adds support to install and use `duckfetch` on Termux.
![duckfetch](https://user-images.githubusercontent.com/49736632/152623894-fa556e10-d645-45d6-afe2-86b58703d98d.png)

