### PR TITLE
Make the install script exit with an error code if it fails and don't hardcode sudo into it.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ the project is a WIP, if you contribute i will be happy c:
 git clone https://github.com/justleoo/duckfetch
 cd duckfetch
 chmod +x ./install
-./install
+sudo ./install
 duckfetch
 ```
   

--- a/install
+++ b/install
@@ -4,13 +4,16 @@ FILE="duckfetch"
 
 if [[ ! -f "./$FILE" ]]; then
     echo "The 'duckfetch' script does not exist."
-    exit
+    exit 1
 fi
 
 if [[ $(uname -o) == "Android" ]]; then
 	cp ./$FILE /data/data/com.termux/files/usr/bin
+elif [[ $(id -u) -eq 0 ]]; then
+	cp ./$FILE /usr/bin
 else
-	sudo cp ./$FILE /usr/bin
+	echo "You need to run this script as root."
+	exit 1
 fi
 
 echo "Installation complete. Run the 'duckfetch' command."

--- a/install
+++ b/install
@@ -9,7 +9,7 @@ fi
 
 if [[ $(uname -o) == "Android" ]]; then
 	cp ./$FILE /data/data/com.termux/files/usr/bin
-elif [[ $(id -u) -eq 0 ]]; then
+elif [[ $(id -u) == 0 ]]; then
 	cp ./$FILE /usr/bin
 else
 	echo "You need to run this script as root."


### PR DESCRIPTION
When the script fails, it does `exit 1` instead of just `exit`.

`sudo` isn't run automatically anymore. Instead, the user needs to call the script with it. The program will detect if it isn't being run as root and fail unless it is being executed inside of Termux. The reason for this is that some users might use `doas` or something else instead of sudo.